### PR TITLE
Add default SSL support with self-signed certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk update && apk upgrade && \
     # Make info file about this build
     printf "Build of nimmis/alpine-apache, date: %s\n"  `date -u +"%Y-%m-%dT%H:%M:%SZ"` >> /etc/BUILD && \
 
-    apk add apache2 libxml2-dev apache2-utils && \
+    apk add apache2 libxml2-dev apache2-utils apache2-ssl && \
     mkdir /web/ && chown -R apache.www-data /web && \
    
     sed -i 's#^DocumentRoot ".*#DocumentRoot "/web/html"#g' /etc/apache2/httpd.conf && \
@@ -20,6 +20,8 @@ RUN apk update && apk upgrade && \
     sed -i 's#PidFile "/run/.*#Pidfile "/web/run/httpd.pid"#g'  /etc/apache2/conf.d/mpm.conf && \
     sed -i 's#Directory "/var/www/localhost/htdocs.*#Directory "/web/html" >#g' /etc/apache2/httpd.conf && \
     sed -i 's#Directory "/var/www/localhost/cgi-bin.*#Directory "/web/cgi-bin" >#g' /etc/apache2/httpd.conf && \
+    sed -i 's#/var/www/localhost/htdocs#/web/html#g' /etc/apache2/conf.d/ssl.conf && \
+    sed -i 's#/var/www/localhost/cgi-bin#/web/cgi-bin#g' /etc/apache2/conf.d/ssl.conf && \
 
     sed -i 's#/var/log/apache2/#/web/logs/#g' /etc/logrotate.d/apache2 && \
     sed -i 's/Options Indexes/Options /g' /etc/apache2/httpd.conf && \


### PR DESCRIPTION
It worth nothing to have minimal SSL access. Just install apache2-ssl and change default ssl.conf file. Users may change ssl.conf to use signed certificates if needed.