### PR TITLE
apache2 fails to restart after log rotation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ MAINTAINER nimmis <kjell.havneskold@gmail.com>
 COPY root/. /
 
 RUN apk update && apk upgrade && \
-
+    #
     # Make info file about this build
     printf "Build of nimmis/alpine-apache, date: %s\n"  `date -u +"%Y-%m-%dT%H:%M:%SZ"` >> /etc/BUILD && \
-
+    #
     apk add apache2 libxml2-dev apache2-utils && \
     mkdir /web/ && chown -R apache.www-data /web && \
-   
+    #
     sed -i 's#^DocumentRoot ".*#DocumentRoot "/web/html"#g' /etc/apache2/httpd.conf && \
     sed -i 's#AllowOverride [Nn]one#AllowOverride All#' /etc/apache2/httpd.conf && \
     sed -i 's#^ServerRoot .*#ServerRoot /web#g'  /etc/apache2/httpd.conf && \
@@ -20,10 +20,11 @@ RUN apk update && apk upgrade && \
     sed -i 's#PidFile "/run/.*#Pidfile "/web/run/httpd.pid"#g'  /etc/apache2/conf.d/mpm.conf && \
     sed -i 's#Directory "/var/www/localhost/htdocs.*#Directory "/web/html" >#g' /etc/apache2/httpd.conf && \
     sed -i 's#Directory "/var/www/localhost/cgi-bin.*#Directory "/web/cgi-bin" >#g' /etc/apache2/httpd.conf && \
-
+    #
     sed -i 's#/var/log/apache2/#/web/logs/#g' /etc/logrotate.d/apache2 && \
+    sed -i 's#^\(.*\)/etc/init.d.*$#\1sv reload /etc/service/apache2 || true#g' /etc/logrotate.d/apache2 && \
     sed -i 's/Options Indexes/Options /g' /etc/apache2/httpd.conf && \
-
+    #
     rm -rf /var/cache/apk/*
 
 VOLUME /web

--- a/root/etc/sv/apache2/run
+++ b/root/etc/sv/apache2/run
@@ -3,10 +3,10 @@
 set -e
 export APACHE_RUN_USER=apache
 export APACHE_RUN_GROUP=www-data
-export APACHE_PID_FILE=/web/run/apache2.pid
+export APACHE_PID_FILE=/web/run/httpd.pid
 export APACHE_RUN_DIR=/var/run/
 export APACHE_LOCK_DIR=/var/lock/
-export APACHE_LOG_DIR=/web/log/
+export APACHE_LOG_DIR=/web/logs/
 
 export LANG=C
 export LANG


### PR DESCRIPTION
I have deployed several containers based upon your excellent docker-alpine-apache image however I have discovered that some containers fail after log rotation.  This pull request changes `logrotate` to reload `apache2` using `runit` vs. the default `init.d` script.  I also fixed a couple `sv run` script environment variables.